### PR TITLE
remove leading zeros on input string before any formatting

### DIFF
--- a/spec/rut-helpers.spec.js
+++ b/spec/rut-helpers.spec.js
@@ -7,11 +7,12 @@ describe('rutHelper', () => {
     });
 
     it('should return true if string is a valid rut without punctuation', () => {
-      expect(rutHelpers.rutValidate('7618212K')).toBe(false);
+      expect(rutHelpers.rutValidate('7618285K')).toBe(true);
     });
 
     it('should return false if string is not a valid rut', () => {
       expect(rutHelpers.rutValidate('7.618.212-K')).toBe(false);
+      expect(rutHelpers.rutValidate('7618212K')).toBe(false);
     });
 
     it('should return false if string is empty', () => {
@@ -28,6 +29,10 @@ describe('rutHelper', () => {
       expect(rutHelpers.rutFormat('7618285K')).toBe('7.618.285-K');
     });
 
+    it('should return formatted rut removing any leading zeros', () => {
+      expect(rutHelpers.rutFormat('0007618285K')).toBe('7.618.285-K');
+    });
+
     it('should return formatted rut if string is an already formatted rut', () => {
       expect(rutHelpers.rutFormat('7.618.285-K')).toBe('7.618.285-K');
     });
@@ -40,6 +45,10 @@ describe('rutHelper', () => {
   describe('rutHelper.rutClean', () => {
     it('should return clean string', () => {
       expect(rutHelpers.rutClean('7.618.285-K')).toBe('7618285K');
+    });
+
+    it('should strip leading zeros', () => {
+      expect(rutHelpers.rutClean('007.618.285-K')).toBe('7618285K');
     });
   });
 });

--- a/spec/rut-helpers.spec.js
+++ b/spec/rut-helpers.spec.js
@@ -49,6 +49,7 @@ describe('rutHelper', () => {
 
     it('should strip leading zeros', () => {
       expect(rutHelpers.rutClean('007.618.285-K')).toBe('7618285K');
+      expect(rutHelpers.rutClean('0.007.618.285-K')).toBe('7618285K');
     });
   });
 });

--- a/src/rut-helpers.ts
+++ b/src/rut-helpers.ts
@@ -1,8 +1,8 @@
 export function rutClean(value: string) {
   if (typeof value === 'string') {
     return value
-      .replace(/^0+/, '')
       .replace(/[^0-9kK]+/g, '')
+      .replace(/^0+/, '')
       .toUpperCase();
   }
   return '';

--- a/src/rut-helpers.ts
+++ b/src/rut-helpers.ts
@@ -1,5 +1,11 @@
 export function rutClean(value: string) {
-  return typeof value === 'string' ? value.replace(/[^0-9kK]+/g, '').toUpperCase() : '';
+  if (typeof value === 'string') {
+    return value
+      .replace(/^0+/, '')
+      .replace(/[^0-9kK]+/g, '')
+      .toUpperCase();
+  }
+  return '';
 }
 
 export function rutValidate(value: string) {


### PR DESCRIPTION
The input string may come from sources that store a RUT without format but with leading zeros.
The clean method used before formatting should take care of it